### PR TITLE
Add condition to sendMessage for successful builds only

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -487,7 +487,15 @@ jobs:
   sendMessage:
     runs-on: ubuntu-latest
     needs: [build_android, build_windows, build_linux, build_ios, build_macos]
-    if: always()
+    if:  |
+      always() && 
+      !contains(needs.*.result, 'failure') && 
+      !contains(needs.*.result, 'cancelled') &&
+      (needs.build_android.result == 'success' ||
+       needs.build_windows.result == 'success' ||
+       needs.build_linux.result == 'success' ||
+       needs.build_ios.result == 'success' ||
+       needs.build_macos.result == 'success')
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
The `sendMessage` job will now:
- **Not send a message** if any build jobs failed or were cancelled.
- **Only send a message** if **at least one** of the build jobs succeeded.

This avoids notifications when builds fail, get cancelled, or when there’s just a commit without any successful builds.
