### PR TITLE
feat: migrate Windows installer from Inno Setup to unsigned MSIX

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -255,19 +255,12 @@ jobs:
     steps:
       - *checkout
 
-      - name: Set up Signing Tool
-        run: |
-          mkdir $env:USERPROFILE\certs
-          [System.IO.File]::WriteAllBytes("$env:USERPROFILE\certs\Dartotsu.pfx", [Convert]::FromBase64String("${{secrets.PFX_FILE}}"))
       - *setup_env
       - *prepare_flutter
       - *setup_flutter
       - *cache_flutter_normal
       - *cache_flutter_clean
-      - name: Setup NuGet.exe for use with actions
-        uses: NuGet/setup-nuget@v2.0.1
-        with:
-          nuget-version: "latest"
+
       - name: Enable Windows desktop support
         run: flutter config --enable-windows-desktop
 
@@ -278,40 +271,38 @@ jobs:
         id: get_version
         run: |
           $version = (Get-Content pubspec.yaml | Select-String -Pattern 'version: ([\d.]+)').Matches.Groups[1].Value
+          $msixVersion = "$version.0"
           echo "version=$version" >> $env:GITHUB_ENV
+          echo "msix_version=$msixVersion" >> $env:GITHUB_ENV
 
-      - name: Find Latest SignTool Path
-        id: find_signtool
-        shell: pwsh
+      - name: Update MSIX version in pubspec.yaml
         run: |
-          $sdkBins = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Directory | 
-                     Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |  
-                     Sort-Object Name -Descending | 
-                     Select-Object -First 1
-          if (-not $sdkBins) {
-            throw "No Windows SDK bin directories found!"
-          }
-          $signtoolPath = Join-Path $sdkBins.FullName "x64\signtool.exe"
-          if (-not (Test-Path $signtoolPath)) {
-            throw "signtool.exe not found at $signtoolPath"
-          }
-          echo "signtool_path=$signtoolPath" >> $env:GITHUB_OUTPUT
+          (Get-Content pubspec.yaml) -replace 'msix_version: [\d.]+', "msix_version: $env:msix_version" | Set-Content pubspec.yaml
 
-      - name: Build and Sign Setup
+      - name: Build unsigned MSIX package
         run: |
-          dart run inno_bundle:build --sign-tool-params '"${{ steps.find_signtool.outputs.signtool_path }}" sign /fd sha256 /f "C:\Users\runneradmin\certs\Dartotsu.pfx" /p "${{secrets.PFX_PASSWORD}}" /tr http://timestamp.digicert.com /td sha256 /v $f' --release
+          Write-Host "Building unsigned MSIX package..."
+          Write-Host "Note: Users must enable Developer Mode to install unsigned MSIX packages"
+          flutter pub run msix:create
+
+      - name: Rename MSIX with version
+        run: |
+          $sourcePath = "build\windows\x64\runner\Release\dartotsu.msix"
+          $destPath = "build\windows\x64\runner\Release\Dartotsu-$env:msix_version-x64.msix"
+          Move-Item -Path $sourcePath -Destination $destPath -Force
+          Write-Host "Renamed MSIX to: $destPath"
 
       - name: Upload File To Google Drive
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         id: gdriveUpload
         uses: hoatruongdev09/google-drive-file-upload-github-action@v1.1
         with:
-          file-path: build\windows\x64\installer\Release\Dartotsu-x86_64-${{env.version}}-Installer.exe
-          upload-name: Dartotsu_windows.exe
+          file-path: build\windows\x64\runner\Release\Dartotsu-${{env.msix_version}}-x64.msix
+          upload-name: Dartotsu-${{env.version}}-windows.msix
           upload-to-folder-id: ${{secrets.GOOGLE_FOLDER_MAIN}}
           service-account-json: "${{secrets.GOOGLE_KEY}}"
           overrwrite: true
-  
+
   build_linux:
     runs-on: ubuntu-latest
     container:
@@ -463,8 +454,8 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' &&
       github.event_name != 'pull_request' &&
-      always() && 
-      !contains(needs.*.result, 'failure') && 
+      always() &&
+      !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (needs.build_android.result == 'success' ||
        needs.build_windows.result == 'success' ||
@@ -761,8 +752,8 @@ jobs:
     if: |
       github.ref == 'refs/heads/main' &&
       github.event_name != 'pull_request' &&
-      always() && 
-      !contains(needs.*.result, 'failure') && 
+      always() &&
+      !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (needs.build_android.result == 'success' ||
        needs.build_windows.result == 'success' ||

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-flutter-
 
-      - name: Set up Signing Tool
-        run: |
-          mkdir $env:USERPROFILE\certs
-          [System.IO.File]::WriteAllBytes("$env:USERPROFILE\certs\Dartotsu.pfx", [Convert]::FromBase64String("${{secrets.PFX_FILE}}"))
       # Create .env:
       - name: Setup env File
         env:
@@ -130,10 +126,6 @@ jobs:
         with:
           flutter-version: 3.35.7
           cache: true
-      - name: Setup NuGet.exe for use with actions
-        uses: NuGet/setup-nuget@v2.0.1
-        with:
-          nuget-version: "latest"
       # Enable Windows desktop support
       - name: Enable Windows desktop support
         run: flutter config --enable-windows-desktop
@@ -147,32 +139,31 @@ jobs:
         id: get_version
         run: |
           $version = (Get-Content pubspec.yaml | Select-String -Pattern 'version: ([\d.]+)').Matches.Groups[1].Value
+          $msixVersion = "$version.0"
           echo "version=$version" >> $env:GITHUB_ENV
+          echo "msix_version=$msixVersion" >> $env:GITHUB_ENV
 
-      - name: Find Latest SignTool Path
-        id: find_signtool
-        shell: pwsh 
+      - name: Update MSIX version in pubspec.yaml
         run: |
-          $sdkBins = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Directory | 
-                     Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |  
-                     Sort-Object Name -Descending | 
-                     Select-Object -First 1
-          if (-not $sdkBins) {
-            throw "No Windows SDK bin directories found!"
-          }
-          $signtoolPath = Join-Path $sdkBins.FullName "x64\signtool.exe"
-          if (-not (Test-Path $signtoolPath)) {
-            throw "signtool.exe not found at $signtoolPath"
-          }
-          echo "signtool_path=$signtoolPath" >> $env:GITHUB_OUTPUT
+          (Get-Content pubspec.yaml) -replace 'msix_version: [\d.]+', "msix_version: $env:msix_version" | Set-Content pubspec.yaml
 
-      - name: Build and Sign Setup
+      - name: Build unsigned MSIX package
         run: |
-          dart run inno_bundle:build --sign-tool-params '"${{ steps.find_signtool.outputs.signtool_path }}" sign /fd sha256 /f "C:\Users\runneradmin\certs\Dartotsu.pfx" /p "${{secrets.PFX_PASSWORD}}" /tr http://timestamp.digicert.com /td sha256 /v $f' --release
-      - name: Release Windows Zip
+          Write-Host "Building unsigned MSIX package..."
+          Write-Host "Note: Users must enable Developer Mode to install unsigned MSIX packages"
+          flutter pub run msix:create
+
+      - name: Rename MSIX with version
+        run: |
+          $sourcePath = "build\windows\x64\runner\Release\dartotsu.msix"
+          $destPath = "build\windows\x64\runner\Release\Dartotsu-$env:msix_version-x64.msix"
+          Move-Item -Path $sourcePath -Destination $destPath -Force
+          Write-Host "Renamed MSIX to: $destPath"
+
+      - name: Release Windows MSIX
         uses: softprops/action-gh-release@master
         with:
-          files: build/windows/x64/installer/Release/Dartotsu-x86_64-${{env.version}}-Installer.exe
+          files: build/windows/x64/runner/Release/Dartotsu-${{env.msix_version}}-x64.msix
 
   build_linux:
     runs-on: ubuntu-latest

--- a/docs/window-install.md
+++ b/docs/window-install.md
@@ -1,0 +1,212 @@
+# Windows Installation Guide
+
+This guide explains how to install and update **Dartotsu** on Windows using the MSIX package.
+
+## Prerequisites
+
+- **Windows 10 version 1809** or later, or **Windows 11**
+- **Developer Mode enabled** (required for unsigned MSIX packages)
+
+## Important Note
+
+The MSIX package is **unsigned** because code signing certificates from trusted Certificate Authorities cost $100-400 per year. This means you **must enable Developer Mode** to install the app.
+
+Enabling Developer Mode is safe and commonly used by developers and power users. It allows Windows to install apps that aren't signed by a trusted certificate authority.
+
+## Installation Steps
+
+### Step 1: Enable Developer Mode
+
+1. Open **Settings** (Windows key + I)
+2. Go to **Privacy & Security** → **For developers** (Windows 11)
+   - OR **Update & Security** → **For Developers** (Windows 10)
+3. Turn on **Developer Mode**
+4. Click **Yes** when Windows asks to confirm
+5. Wait for Windows to install the necessary components (this may take a minute)
+
+### Step 2: Download the MSIX Package
+
+1. Go to the [Releases page](https://github.com/grayankit/DantotsuRe/releases)
+2. Download the latest `Dartotsu-x.x.x-x64.msix` file
+
+### Step 3: Install Dartotsu
+
+1. Double-click the downloaded `.msix` file
+2. Click **Install** in the installer window
+3. Wait for installation to complete (usually takes 10-30 seconds)
+4. Click **Launch** to start Dartotsu, or find it in your Start Menu
+
+That's it! Dartotsu is now installed.
+
+---
+
+## Updating Dartotsu
+
+Updates are simple - just download and install the new version:
+
+1. Download the new `.msix` file from releases
+2. Double-click the file
+3. Click **Update** (or **Install** if shown)
+4. Wait for the update to complete
+
+The app will update in place, preserving your settings and data.
+
+**Note:** Developer Mode must still be enabled for updates.
+
+---
+
+## Uninstalling Dartotsu
+
+### Method 1: Windows Settings
+
+1. Open **Settings** → **Apps** → **Installed apps** (Windows 11)
+   - OR **Settings** → **Apps** → **Apps & features** (Windows 10)
+2. Search for **Dartotsu**
+3. Click the three dots **⋮** next to Dartotsu
+4. Click **Uninstall**
+5. Confirm the uninstallation
+
+### Method 2: PowerShell
+
+```powershell
+# Uninstall Dartotsu
+Get-AppxPackage *dartotsu* | Remove-AppxPackage
+```
+
+---
+
+## Troubleshooting
+
+### "Installation Failed" or "Can't Install"
+
+**Problem:** Developer Mode is not enabled.
+
+**Solution:** Follow Step 1 above to enable Developer Mode.
+
+---
+
+### "This app package is not supported for installation"
+
+**Problem:** Your Windows version is too old.
+
+**Solution:** Update to Windows 10 version 1809 or later, or upgrade to Windows 11.
+
+---
+
+### "Installation Blocked by Policy"
+
+**Problem:** Your organization has blocked installing apps from outside the Microsoft Store.
+
+**Solution:** Contact your IT administrator. Developer Mode installation may be disabled by company policy.
+
+---
+
+### MSIX File Won't Open
+
+**Problem:** Windows doesn't recognize the file type.
+
+**Solutions:**
+
+1. Make sure the file extension is `.msix` (not `.msix.txt` or similar)
+2. Right-click the file → **Open with** → **App Installer**
+3. If App Installer is missing, run this in PowerShell as Administrator:
+   ```powershell
+   Add-AppxPackage -Path "C:\path\to\Dartotsu-x.x.x-x64.msix"
+   ```
+
+---
+
+### "App Installer Blocked by Antivirus"
+
+**Problem:** Antivirus software is blocking the installation.
+
+**Solutions:**
+
+1. Temporarily disable your antivirus
+2. Add an exception for the MSIX file
+3. Download from the official GitHub releases page to ensure the file is legitimate
+
+---
+
+## Why is Developer Mode Required?
+
+Developer Mode is required because the MSIX package is **not signed with a trusted certificate**. Here's why:
+
+- **Trusted certificates cost money**: Code signing certificates from Certificate Authorities (like DigiCert, Sectigo) cost $100-400 per year
+- **This is a free, open-source project**: We can't justify that expense for a free app
+- **Developer Mode is safe**: It's designed for developers and power users to test apps
+- **Your data is safe**: Developer Mode doesn't compromise your system security
+
+In the future, if the project gets funding or sponsorship, we may purchase a trusted certificate to make installation easier.
+
+---
+
+## Is This Safe?
+
+**Yes, as long as you download from the official source:**
+
+- ✅ Only download from [GitHub Releases](https://github.com/grayankit/DantotsuRe/releases)
+- ✅ The source code is open and available for review
+- ✅ The app runs in a sandboxed environment (MSIX security)
+- ✅ Enabling Developer Mode doesn't create security holes
+- ⚠️ Never download MSIX files from unofficial sources
+- ⚠️ Always verify you're on the correct GitHub repository
+
+---
+
+## System Requirements
+
+- **OS:** Windows 10 version 1809 or later, or Windows 11
+- **Architecture:** x64 (64-bit)
+- **Disk Space:** ~200 MB for installation
+- **RAM:** 4 GB minimum (8 GB recommended)
+- **Processor:** 1.8 GHz or faster
+
+---
+
+## Data Location
+
+After installation, Dartotsu stores its data in:
+
+- **Settings:** `%APPDATA%\Dantotsu`
+- **Cache:** `%LOCALAPPDATA%\Dantotsu`
+- **Logs:** `%APPDATA%\Dantotsu\logs`
+
+---
+
+## Can I Disable Developer Mode After Installing?
+
+**No.** If you disable Developer Mode, Windows will prevent the app from running. You need to keep Developer Mode enabled as long as you want to use Dartotsu.
+
+If this is a concern, you can wait until we obtain a trusted certificate in the future (if/when that happens).
+
+---
+
+## Alternative: Use the Android Version
+
+If you prefer not to enable Developer Mode, you can use Dartotsu on Android instead:
+
+- Install via APK from GitHub Releases
+- No special settings required on Android
+- Same features and functionality
+
+---
+
+## Need Help?
+
+If you encounter issues not covered in this guide:
+
+1. Check the [GitHub Issues](https://github.com/grayankit/DantotsuRe/issues)
+2. Create a new issue with:
+   - Windows version
+   - Whether Developer Mode is enabled
+   - Error messages (screenshots help!)
+   - Steps to reproduce
+
+---
+
+## See Also
+
+- [Release Notes](../release.md)
+- [Official Repository](https://github.com/grayankit/DantotsuRe)
+- [Why Code Signing Certificates Cost Money](https://docs.microsoft.com/en-us/windows/msix/package/signing-package-overview)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -119,7 +119,7 @@ dev_dependencies:
   isar_community_generator: ^3.3.2
   json_serializable: ^6.0.1
   build_runner: ^2.13.1
-  inno_bundle: ^0.11.2
+  msix: ^3.16.7
 dependency_overrides:
   collection: ^1.19.1
 # Flutter-specific configurations
@@ -162,14 +162,14 @@ flutter_icons:
     generate: true
     image_path: "assets/images/logo.png"
 
-inno_bundle:
-  sign_tool:
-    command: $p
-  id: 609d9fb9-ac99-533b-a5b5-f277afa99b68
-  publisher: Ankit Grai
-  name: Dartotsu
-  version: 0.0.4
-  admin: auto
-  installer_icon: assets/images/lol.ico
-  languages:
-    - english
+msix_config:
+  display_name: Dartotsu
+  publisher_display_name: Ankit Grai
+  identity_name: com.ankitgrai.dartotsu
+  publisher: CN=Ankit Grai
+  msix_version: 0.0.4.0
+  logo_path: assets/images/logo.png
+  capabilities: internetClient, privateNetworkClientServer
+  languages: en-us
+  architecture: x64
+  install_certificate: false


### PR DESCRIPTION
- Replace Inno Setup (.exe) with MSIX package format
- MSIX packages are unsigned (trusted certs cost $100-400/year)
- Users must enable Developer Mode to install unsigned MSIX
- Update pubspec.yaml: replace inno_bundle with msix package
- Configure MSIX: publisher, logo, capabilities
- Update workflows to build and rename MSIX packages
- Add comprehensive windows-install.md guide
- Explain Developer Mode requirement and safety

Breaking change: Users must uninstall old Inno Setup version first
Benefit: Future updates will be seamless with MSIX

<!--
# Pull Request
**Description:**  
Submit changes or improvements to Dartotsu

**Title:**  
Provide a concise and descriptive title for your pull request

**Description:**  
Clearly describe the purpose and scope of your pull request

**Summary of Changes:**  
Outline the key changes introduced in this pull request

**Type of Changes:**  
- Bug Fix
- Feature
- Enhancement
- Documentation

**Testing Notes:**  
Provide details on how this change has been tested

**Linked Issue(s):**  
Mention any related issues using their GitHub issue numbers

**Additional Context:**  
Include any other relevant information or context for your pull request

**Submission Checklist:**
- [ ] I have read and followed the project's contributing guidelines
- [ ] My code follows the code style of this project
- [ ] I have tested the changes and ensured they do not break existing functionality
- [ ] I have added or updated documentation as needed
- [ ] I have linked related issues in the description above
- [ ] I have tagged the appropriate reviewers for this pull request
-->
